### PR TITLE
Agrega comando para instalar librería faltante

### DIFF
--- a/Chapters/Chapter1.tex
+++ b/Chapters/Chapter1.tex
@@ -136,6 +136,7 @@ Se indican a continuación los comandos que se deben introducir en la consola de
   $ sudo apt install texlive-lang-spanish texlive-science 
   $ sudo apt install texlive-bibtex-extra biber
   $ sudo apt install texlive texlive-fonts-recommended
+  $ sudo apt install texlive-latex-extra
 \end{lstlisting}
 
 


### PR DESCRIPTION
@patriciobos esta *pull request* agrega:
- `sudo apt install texlive-latex-extra` para evitar el error que tuvimos con `xpatch`
- En la línea final marca un cambio, pero no se si es un espacio o qué será 